### PR TITLE
perf: Specify RemoteApp Machine's system requirement. Windows  Server 2019 Essential doesn't support RDS.

### DIFF
--- a/src/pages/docs/remoteapp/remoteapp-machine.mdx
+++ b/src/pages/docs/remoteapp/remoteapp-machine.mdx
@@ -8,7 +8,7 @@
 
 The RemoteApp machine must meet the following requirements:
 
-- Running Windows Server 2019 operating system.
+- Running Windows Server 2019 Standard or Datacenter operating system.
 - At least 4 CPU cores and 8 GB of RAM.
 - OpenSSH or WinRM is installed and configured.
 - Remote Desktop Services (RDS) license is installed and activated.


### PR DESCRIPTION
perf: Specify RemoteApp Machine's system requirement. Windows  Server 2019 Essential doesn't support RDS. 